### PR TITLE
Stack Overflow as the site name includes a space

### DIFF
--- a/content/_layout/footer.slim
+++ b/content/_layout/footer.slim
@@ -75,7 +75,7 @@ Layout: false
         markdown:
           We [encourage feedback and feature requests on our UserVoice site](http://resizer.uservoice.com/forums/108373-image-resizer), where others can vote on your proposals.
 
-          For support requests, [visit our support page, which explains how to generate a diagnostics page and get free support on StackOverflow](/support). 
+          For support requests, [visit our support page, which explains how to generate a diagnostics page and get free support on Stack Overflow](/support). 
 
           We provide free support for all bug-related requests, and [**offer a $5-$50 reward** for discovering a bug (details)](/support#bugbounty). 
 

--- a/content/blog/2013/hiring.md
+++ b/content/blog/2013/hiring.md
@@ -11,7 +11,7 @@ Imazen is hiring talented, experienced software engineers who have a history of 
 
 **Perks:** 20% time, MBP retina hardware, 100% remote, flexible hours, high-quality codebase.
 
-You can apply [at StackOverflow Careers (make sure you're logged in to StackOverflow first!)](http://careers.stackoverflow.com/jobs/32425/work-on-open-source-imaging-software-in-c-sharp-c-imazen)
+You can apply [at Stack Overflow Careers (make sure you're logged in to Stack Overflow first!)](http://careers.stackoverflow.com/jobs/32425/work-on-open-source-imaging-software-in-c-sharp-c-imazen)
 
 More details about [other Imazen job openings can be found at imazen.io/careers](http://www.imazen.io/careers).
 

--- a/content/docs/benefits/index.slim
+++ b/content/docs/benefits/index.slim
@@ -46,7 +46,7 @@ h1 Benefits
       .icons-box
         i.ico-white.circle-color-full.ico-group
         h3 Helpful community
-        p ImageResizer boasts a sizeable collection of community plugins, and there are always people around to give you a hand at StackOverflow:ImageResizer when the self-diagnostics can't help.
+        p ImageResizer boasts a sizeable collection of community plugins, and there are always people around to give you a hand at Stack Overflow:ImageResizer when the self-diagnostics can't help.
         .clear
   .span3
     a.block.plaintext href="/docs/benefits/agile"

--- a/content/docs/community.slim
+++ b/content/docs/community.slim
@@ -74,7 +74,7 @@ h1 ImageResizer Community
     
     .title: h2 Community Support
     markdown:
-      Many ImageResizer users [monitor StackOverflow for questions tagged *imageresizer*](http://stackoverflow.com/questions/tagged/imageresizer), and may answer your question before we can get to it. 
+      Many ImageResizer users [monitor Stack Overflow for questions tagged *imageresizer*](http://stackoverflow.com/questions/tagged/imageresizer), and may answer your question before we can get to it. 
 
       Please be courteous; vote good answers up, and mark them as accepted. Make sure your questions include a gist with the diagnostics page output, and you've included all relevant details and detailed error messages. It's best to register and select a username instead of posting anonymously; anonymous posts are often considered spam.
 
@@ -110,7 +110,7 @@ h1 ImageResizer Community
       * [heltBlank: Umbraco and ImageResizer](http://heltblank.wordpress.com/2012/02/13/imageresizing-net-and-umbraco-5-jupiter/)
       * [uBootstrap for Umbraco](http://our.umbraco.org/projects/starter-kits/ubootstrap) now [includes ImageResizer to handle responsive imaging needs](http://jlusar.es/ubootstrap-fluent-layout)
 
-      There are also over [50 StackOverflow posts about ImageResizer](http://stackoverflow.com/questions/tagged/imageresizer).
+      There are also over [70 Stack Overflow posts about ImageResizer](http://stackoverflow.com/questions/tagged/imageresizer).
 
 
 

--- a/content/support/index.slim
+++ b/content/support/index.slim
@@ -15,7 +15,7 @@ h1 Support
 
 				1. Visit the [self-diagnostics page](/plugins/diagnostics) on your server: `/resizer.debug.ashx`
 				2. Enable [detailed error messages, and visit the image URL directly](/docs/geterror)
-				3. Skim the comprehensive [troubleshooting guide](/docs/troubleshoot) and [faq](/docs/faq). If it's a *how-to* question, [try reading the documentation](/docs), [searching this site](/search), and [searching StackOverflow](http://stackoverflow.com/questions/tagged/imageresizer).
+				3. Skim the comprehensive [troubleshooting guide](/docs/troubleshoot) and [faq](/docs/faq). If it's a *how-to* question, [try reading the documentation](/docs), [searching this site](/search), and [searching Stack Overflow](http://stackoverflow.com/questions/tagged/imageresizer).
 				
 			hr
 			markdown:
@@ -26,7 +26,7 @@ h1 Support
 
 			* [Troubleshooting Guide](/docs/troubleshoot)
 			* [Frequently Asked Questions](/docs/faq)
-			* [StackOverflow: ImageResizer](http://stackoverflow.com/questions/tagged/imageresizer)
+			* [Stack Overflow: ImageResizer](http://stackoverflow.com/questions/tagged/imageresizer)
 			* [UserVoice: ImageResizer](http://resizer.uservoice.com/forums/108373-image-resizer-v3)
 			* [How to view the diagnostics page](/plugins/diagnostics)
 			* [How to enable detailed error messages](/docs/geterror)
@@ -78,7 +78,7 @@ hr
 
 		h2 id="bugbounty" Bug bounty program
 		markdown: 
-			We offer free support for all *bug-related* inquiries through e-mail (**support@imageresizing.net**) and [StackOverflow](http://stackoverflow.com/questions/tagged/imageresizer).
+			We offer free support for all *bug-related* inquiries through e-mail (**support@imageresizing.net**) and [Stack Overflow](http://stackoverflow.com/questions/tagged/imageresizer).
 
 			We will also PayPal you between $5 and $50 for each bug you report if you're the first to report it, and if it's in the latest version of one of our ImageResizer.* assemblies.
 
@@ -86,18 +86,18 @@ hr
 
 			We welcome feature requests, and everyone may [sumbit new ideas or vote for existing ones at the uservoice site](http://resizer.uservoice.com/forums/108373-image-resizer-v3).
 	.span6
-		h2 Free support on StackOverflow
+		h2 Free support on Stack Overflow
 		markdown:
-			Free support is provided for [questions posted on StackOverflow](http://stackoverflow.com/questions/tagged/imageresizer), *if they meet the following criteria*:
+			Free support is provided for [questions posted on Stack Overflow](http://stackoverflow.com/questions/tagged/imageresizer), *if they meet the following criteria*:
 
 			1. The question is [tagged 'imageresizer'](http://stackoverflow.com/questions/tagged/imageresizer) so we can find it.
 			2. The question [includes a gist](https://gist.github.com/) with the diagnostics page output.
 			3. The question is about the URL API and [follows best praticies](/docs/best-practices).
 			4. The question is detailed enough to answer and shows some diagnostic effort.
 
-			We typically answer StackOverflow questions within 1-2 weeks. E-mail your question URL to **support@imageresizing.net** for a faster response. 
+			We typically answer Stack Overflow questions within 1-2 weeks. E-mail your question URL to **support@imageresizing.net** for a faster response. 
 
-			If we take the time to provide a good answer to your question, please be courteous; mark it as the answer and vote it up. We prioritize questions from StackOverflow users with a good reputation.
+			If we take the time to provide a good answer to your question, please be courteous; mark it as the answer and vote it up. We prioritize questions from Stack Overflow users with a good reputation.
 
 
 


### PR DESCRIPTION
Typo kind of fix. If you count how pronouns are spaced as a typo.
